### PR TITLE
remove write permission from output files

### DIFF
--- a/gpipe/workflow/sge/single_task_script_template.sh.j2
+++ b/gpipe/workflow/sge/single_task_script_template.sh.j2
@@ -121,6 +121,7 @@ cd $gpipe_meta_work_directory
 if [ $gpipe_meta_num_outputs -ge 1 ]; then
     for o in "${gpipe_meta_outputs[@]}"; do
         test -e $o
+        chmod ugo-w $o
     done
 fi
 


### PR DESCRIPTION
automatically removes write permission from files generated by task script, in order to avoid accidentally overwrite output files